### PR TITLE
Add missing include for windows.

### DIFF
--- a/src/c/netty_jni_util.c
+++ b/src/c/netty_jni_util.c
@@ -36,6 +36,7 @@
 #include <dlfcn.h>
 #else
 #define MAX_DLL_PATH_LEN 2048
+#include <windows.h>
 #endif // _WIN32
 
 #include <stdlib.h>


### PR DESCRIPTION
Motivation:

We need to include windows.h to be able to build

Modifications:

Add windows.h as include

Result:

Works on windows