### PR TITLE
Avoid static state

### DIFF
--- a/src/main/c/netty_jni_util.c
+++ b/src/main/c/netty_jni_util.c
@@ -43,8 +43,6 @@
 #include <string.h>
 #include "netty_jni_util.h"
 
-static char*     staticPackagePrefix;
-
 void netty_jni_util_free_dynamic_methods_table(JNINativeMethod* dynamicMethods, jint fixedMethodTableSize, jint fullMethodTableSize) {
     if (dynamicMethods != NULL) {
         jint i = fixedMethodTableSize;
@@ -463,17 +461,11 @@ jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, 
 #endif /* NETTY_JNI_UTIL_BUILD_STATIC */
 
     jint ret = load_function(env, packagePrefix);
-    if (ret == JNI_ERR) {
-        free(packagePrefix);
-        staticPackagePrefix = NULL;
-    } else {
-        // This will be freed when we unload.
-        staticPackagePrefix = packagePrefix;
-    }
+    free(packagePrefix);
     return ret;
 }
 
-void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_function)(JNIEnv*, const char*)) {
+void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_function)(JNIEnv*)) {
     JNIEnv* env = NULL;
     if ((*vm)->GetEnv(vm, (void**) &env, NETTY_JNI_UTIL_JNI_VERSION) != JNI_OK) {
         fprintf(stderr, "FATAL: JNI version missmatch");
@@ -481,7 +473,5 @@ void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_funct
         // Something is wrong but nothing we can do about this :(
         return;
     }
-    unload_function(env, staticPackagePrefix);
-    free(staticPackagePrefix);
-    staticPackagePrefix = NULL;
+    unload_function(env);
 }

--- a/src/main/c/netty_jni_util.h
+++ b/src/main/c/netty_jni_util.h
@@ -127,6 +127,6 @@ jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, 
 /**
  * Function should be called when the native library is unloaded
  */
-void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_function)(JNIEnv*, const char*));
+void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_function)(JNIEnv*));
 
 #endif /* NETTY_JNI_UTIL_H_ */


### PR DESCRIPTION
Motivation:

When statically compiled, the same netty-jni-util may be used by
multiple separate JNI libraries. In this situation there is only one
copy of static variables, so it is only safe to use static variables in
cases where they can safely be reused. That's not the case for the
current staticPackagePrefix.

Modifications:

Force the caller to manage the static state, which can be unique per
usage.

Result:

Static compilation is available again for JNI libraries that supported
static compilation before depending on netty-jni-util. Fixes #5.