### PR TITLE
Fix typo in error message

### DIFF
--- a/src/main/c/netty_jni_util.c
+++ b/src/main/c/netty_jni_util.c
@@ -408,7 +408,7 @@ static int dladdr(void *ptr, Dl_info *dl)
 jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, jint (*load_function)(JNIEnv*, const char*)) {
     JNIEnv* env = NULL;
     if ((*vm)->GetEnv(vm, (void**) &env, NETTY_JNI_UTIL_JNI_VERSION) != JNI_OK) {
-        fprintf(stderr, "FATAL: JNI version missmatch");
+        fprintf(stderr, "FATAL: JNI version mismatch");
         fflush(stderr);
         return JNI_ERR;
     }
@@ -468,7 +468,7 @@ jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, 
 void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_function)(JNIEnv*)) {
     JNIEnv* env = NULL;
     if ((*vm)->GetEnv(vm, (void**) &env, NETTY_JNI_UTIL_JNI_VERSION) != JNI_OK) {
-        fprintf(stderr, "FATAL: JNI version missmatch");
+        fprintf(stderr, "FATAL: JNI version mismatch");
         fflush(stderr);
         // Something is wrong but nothing we can do about this :(
         return;


### PR DESCRIPTION
Motivation:

There are some typos in error message (JNI version mismatch).

Modification:

Fix typos in source codes.