### PR TITLE
Avoid use of strdup, strndup

### DIFF
--- a/src/main/c/netty_jni_util.c
+++ b/src/main/c/netty_jni_util.c
@@ -437,7 +437,6 @@ jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, 
 #endif /* NETTY_JNI_UTIL_BUILD_STATIC */
 
     jint ret = load_function(env, packagePrefix);
-    free(packagePrefix);
     return ret;
 }
 

--- a/src/main/c/netty_jni_util.h
+++ b/src/main/c/netty_jni_util.h
@@ -120,13 +120,13 @@ void netty_jni_util_free_dynamic_methods_table(JNINativeMethod* dynamicMethods, 
 void netty_jni_util_free_dynamic_name(char** dynamicName);
 
 /**
- * Function should be called when the native library is loaded
+ * Function should be called when the native library is loaded. load_function takes ownership of packagePrefix.
  */
-jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, jint (*load_function)(JNIEnv*, const char*));
+jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, jint (*load_function)(JNIEnv* env, const char* packagePrefix));
 
 /**
  * Function should be called when the native library is unloaded
  */
-void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_function)(JNIEnv*));
+void netty_jni_util_JNI_OnUnload(JavaVM* vm, void* reserved, void (*unload_function)(JNIEnv* env));
 
 #endif /* NETTY_JNI_UTIL_H_ */


### PR DESCRIPTION
* Avoid use of strndup

On old glibc, strdup and strndup are aliased to __strdup and __strndup,
which musl does not implement. This causes netty to unnecessarily fail
on musl. strndup is not the right tool here anyways, since we know the
exact size of the string to be duplicated, not the maximum size.

* Don't free packagePrefix after load_function

This allows load_function to avoid calling strdup, which is both more
efficient and also improves musl compatibility.