### PR TITLE
Move declaration out of for loop

### DIFF
--- a/src/main/c/netty_jni_util.c
+++ b/src/main/c/netty_jni_util.c
@@ -212,7 +212,8 @@ static char* parsePackagePrefix(const char* libraryPathName, const char* libname
         newPackagePrefix[--packagePrefixLen] = '/';
     }
     // Package names must be sanitized, in JNI packages names are separated by '/' characters.
-    for (size_t i = 0; i < packagePrefixLen; ++i) {
+    size_t i;
+    for (i = 0; i < packagePrefixLen; ++i) {
         if (newPackagePrefix[i] == '_') {
             newPackagePrefix[i] = '/';
         }


### PR DESCRIPTION
Motivation:

Let's move the declaration out of the for loop so we dont netty to use -std=c99

Modifications:

Move declaration out of loop

Result:

No extra CFLAGS needed