### PR TITLE
Replace forked code which has no clear attribution / license with ASL…

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -26,3 +26,11 @@ This product contains the Maven wrapper scripts from 'Maven Wrapper', that provi
     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
+
+This product contains small piece of code to support AIX, taken from netbsd.
+
+  * LICENSE:
+    * license/LICENSE.aix-netbsd.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://netbsd.org
+

--- a/license/LICENSE.aix-netbsd.txt
+++ b/license/LICENSE.aix-netbsd.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/src/main/c/netty_jni_util.c
+++ b/src/main/c/netty_jni_util.c
@@ -256,8 +256,6 @@ static char* parsePackagePrefix(const char* libraryPathName, const char* libname
 #endif /* NETTY_JNI_UTIL_BUILD_STATIC */
 
 /* Fix missing Dl_info & dladdr in AIX
- * The code is taken from netbsd.org (src/crypto/external/bsd/openssl/dist/crypto/dso/dso_dlfcn.c)
- * except strlcpy & strlcat (those are taken from openbsd.org (src/lib/libc/string))
  */
 #ifdef _AIX
 /*-
@@ -268,73 +266,35 @@ static char* parsePackagePrefix(const char* libraryPathName, const char* libname
 #include <sys/ldr.h>
 #include <errno.h>
 
-/* strlcpy:
- * Copy string src to buffer dst of size dsize.  At most dsize-1
- * chars will be copied.  Always NUL terminates (unless dsize == 0).
- * Returns strlen(src); if retval >= dsize, truncation occurred.
- */
-size_t strlcpy(char *dst, const char *src, size_t dsize)
+// The code is taken from netbsd.org:
+// https://cvsweb.netbsd.org/bsdweb.cgi/src/crypto/external/bsd/openssl/dist/crypto/
+// o_str.c?rev=1.1.1.11.2.1;content-type=text%2Fplain
+size_t strlcpy(char *dst, const char *src, size_t size)
 {
-    const char *osrc = src;
-    size_t nleft = dsize;
-
-    /* Copy as many bytes as will fit. */
-    if (nleft != 0) {
-        while (--nleft != 0) {
-            if ((*dst++ = *src++) == '\0') {
-                break;
-            }
-        }
+    size_t l = 0;
+    for (; size > 1 && *src; size--) {
+        *dst++ = *src++;
+        l++;
     }
-
-    /* Not enough room in dst, add NUL and traverse rest of src. */
-    if (nleft == 0) {
-        if (dsize != 0) {
-            *dst = '\0';		/* NUL-terminate dst */
-        }
-        while (*src++) {
-            ;
-        }
-    }
-
-    return src - osrc - 1;	/* count does not include NUL */
+    if (size)
+        *dst = CH_ZERO;
+    return l + strlen(src);
 }
 
-/* strlcat:
- * Appends src to string dst of size dsize (unlike strncat, dsize is the
- * full size of dst, not space left).  At most dsize-1 characters
- * will be copied.  Always NUL terminates (unless dsize <= strlen(dst)).
- * Returns strlen(src) + MIN(dsize, strlen(initial dst)).
- * If retval >= dsize, truncation occurred.
- */
-size_t strlcat(char *dst, const char *src, size_t dsize)
+// The code is taken from netbsd.org:
+// https://cvsweb.netbsd.org/bsdweb.cgi/src/crypto/external/bsd/openssl/dist/crypto/
+// o_str.c?rev=1.1.1.11.2.1;content-type=text%2Fplain
+size_t strlcat(char *dst, const char *src, size_t size)
 {
-    const char *odst = dst;
-    const char *osrc = src;
-    size_t n = dsize;
-    size_t dlen;
-
-    /* Find the end of dst and adjust bytes left but don't go past end. */
-    while (n-- != 0 && *dst != '\0') {
-        dst++;
-    }
-    dlen = dst - odst;
-    n = dsize - dlen;
-
-    if (n-- == 0) {
-        return dlen + strlen(src);
-    }
-    while (*src != '\0') {
-        if (n != 0) {
-            *dst++ = *src;
-            n--;
-        }
-        src++;
-    }
-    *dst = '\0';
-
-    return dlen + src - osrc;	/* count does not include NUL */
+    size_t l = 0;
+    for (; size > 0 && *dst; size--, dst++)
+        l++;
+    return l + strlcpy(dst, src, size);
 }
+
+// The code is taken from netbsd.org:
+// https://cvsweb.netbsd.org/bsdweb.cgi/src/crypto/external/bsd/openssl/dist/
+// crypto/dso/dso_dlfcn.c?rev=1.17.2.1;content-type=text%2Fplain
 
 /* ~ 64 * (sizeof(struct ld_info) + _XOPEN_PATH_MAX + _XOPEN_NAME_MAX) */
 #  define DLFCN_LDINFO_SIZE 86976
@@ -342,76 +302,75 @@ typedef struct Dl_info {
     const char *dli_fname;
 } Dl_info;
 /*
- * This dladdr()-implementation will also find the ptrgl (Pointer Glue) virtual
- * address of a function, which is just located in the DATA segment instead of
- * the TEXT segment.
- */
-static int dladdr(void *ptr, Dl_info *dl)
-{
-    uintptr_t addr = (uintptr_t)ptr;
-    struct ld_info *ldinfos;
-    struct ld_info *next_ldi;
-    struct ld_info *this_ldi;
+  * This dladdr()-implementation will also find the ptrgl (Pointer Glue) virtual
+  * address of a function, which is just located in the DATA segment instead of
+  * the TEXT segment.
+  */
+ static int dladdr(void *ptr, Dl_info *dl)
+ {
+     uintptr_t addr = (uintptr_t)ptr;
+     unsigned int found = 0;
+     struct ld_info *ldinfos, *next_ldi, *this_ldi;
 
-    if ((ldinfos = malloc(DLFCN_LDINFO_SIZE)) == NULL) {
-        dl->dli_fname = NULL;
-        return 0;
-    }
+     if ((ldinfos = malloc(DLFCN_LDINFO_SIZE)) == NULL) {
+         errno = ENOMEM;
+         dl->dli_fname = NULL;
+         return 0;
+     }
 
-    if ((loadquery(L_GETINFO, (void *)ldinfos, DLFCN_LDINFO_SIZE)) < 0) {
-        /*-
-         * Error handling is done through errno and dlerror() reading errno:
-         *  ENOMEM (ldinfos buffer is too small),
-         *  EINVAL (invalid flags),
-         *  EFAULT (invalid ldinfos ptr)
-         */
-        free((void *)ldinfos);
-        dl->dli_fname = NULL;
-        return 0;
-    }
-    next_ldi = ldinfos;
+     if ((loadquery(L_GETINFO, (void *)ldinfos, DLFCN_LDINFO_SIZE)) < 0) {
+         /*-
+          * Error handling is done through errno and dlerror() reading errno:
+          *  ENOMEM (ldinfos buffer is too small),
+          *  EINVAL (invalid flags),
+          *  EFAULT (invalid ldinfos ptr)
+          */
+         free((void *)ldinfos);
+         dl->dli_fname = NULL;
+         return 0;
+     }
+     next_ldi = ldinfos;
 
-    do {
-        this_ldi = next_ldi;
-        if (((addr >= (uintptr_t)this_ldi->ldinfo_textorg)
-             && (addr < ((uintptr_t)this_ldi->ldinfo_textorg +
-                         this_ldi->ldinfo_textsize)))
-            || ((addr >= (uintptr_t)this_ldi->ldinfo_dataorg)
-                && (addr < ((uintptr_t)this_ldi->ldinfo_dataorg +
-                            this_ldi->ldinfo_datasize)))) {
-            char *buffer = NULL;
-            char *member = NULL;
-            size_t buffer_sz;
-            size_t member_len;
+     do {
+         this_ldi = next_ldi;
+         if (((addr >= (uintptr_t)this_ldi->ldinfo_textorg)
+              && (addr < ((uintptr_t)this_ldi->ldinfo_textorg +
+                          this_ldi->ldinfo_textsize)))
+             || ((addr >= (uintptr_t)this_ldi->ldinfo_dataorg)
+                 && (addr < ((uintptr_t)this_ldi->ldinfo_dataorg +
+                             this_ldi->ldinfo_datasize)))) {
+             char *buffer, *member;
+             size_t buffer_sz, member_len;
 
-            buffer_sz = strlen(this_ldi->ldinfo_filename) + 1;
-            member = this_ldi->ldinfo_filename + buffer_sz;
-            if ((member_len = strlen(member)) > 0) {
-                buffer_sz += 1 + member_len + 1;
-            }
-            if ((buffer = malloc(buffer_sz)) != NULL) {
-                strlcpy(buffer, this_ldi->ldinfo_filename, buffer_sz);
-                if (member_len > 0) {
-                    /*
-                     * Need to respect a possible member name and not just
-                     * returning the path name in this case. See docs:
-                     * sys/ldr.h, loadquery() and dlopen()/RTLD_MEMBER.
-                     */
-                    strlcat(buffer, "(", buffer_sz);
-                    strlcat(buffer, member, buffer_sz);
-                    strlcat(buffer, ")", buffer_sz);
-                }
-                dl->dli_fname = buffer;
-            }
-            break;
-        } else {
-            next_ldi = (struct ld_info *)((uintptr_t)this_ldi +
-                                          this_ldi->ldinfo_next);
-        }
-    } while (this_ldi->ldinfo_next);
-    free((void *)ldinfos);
-    return dl->dli_fname != NULL;
-}
+             buffer_sz = strlen(this_ldi->ldinfo_filename) + 1;
+             member = this_ldi->ldinfo_filename + buffer_sz;
+             if ((member_len = strlen(member)) > 0)
+                 buffer_sz += 1 + member_len + 1;
+             found = 1;
+             if ((buffer = malloc(buffer_sz)) != NULL) {
+                 strlcpy(buffer, this_ldi->ldinfo_filename, buffer_sz);
+                 if (member_len > 0) {
+                     /*
+                      * Need to respect a possible member name and not just
+                      * returning the path name in this case. See docs:
+                      * sys/ldr.h, loadquery() and dlopen()/RTLD_MEMBER.
+                      */
+                     strlcat(buffer, "(", buffer_sz);
+                     strlcat(buffer, member, buffer_sz);
+                     strlcat(buffer, ")", buffer_sz);
+                 }
+                 dl->dli_fname = buffer;
+             } else {
+                 errno = ENOMEM;
+             }
+         } else {
+             next_ldi = (struct ld_info *)((uintptr_t)this_ldi +
+                                           this_ldi->ldinfo_next);
+         }
+     } while (this_ldi->ldinfo_next && !found);
+     free((void *)ldinfos);
+     return (found && dl->dli_fname != NULL);
+ }
 #endif /* _AIX */
 
 jint netty_jni_util_JNI_OnLoad(JavaVM* vm, void* reserved, const char* libname, jint (*load_function)(JNIEnv*, const char*)) {


### PR DESCRIPTION
…2 based code

Motivation:

We had some code which had no clear licensing.

Modifications:

- Replace code in question with code forked out of netbsd which is clearly marked as ASL2 based
- Add missing license information

Result:

Fixes https://github.com/netty/netty-jni-util/issues/20