### PR TITLE
Add extra argument to fix cmake build with recent cmake versions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,7 +37,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     - name: Build
       working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
Motivation:

We need to add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to be able to build with recent cnmake versions

Modifications:

Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5

Result:

Workflow works again